### PR TITLE
Dedicated Asus Zenfone Max Pro M1 & M2 branch unification

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -471,7 +471,7 @@ KERNEL_MADE="$(file_getprop anykernel.sh kernel.made)";
 KERNEL_VERSION="$(file_getprop anykernel.sh kernel.version)";
 BUILD_DATE=$(date +%Y-%m-%d)
 MESSAGE_WORD="$(file_getprop anykernel.sh message.word)";
-DEVICE_NAME="$(file_getprop anykernel.sh device.name3)";
+DEVICE_NAME="$(getprop ro.product.device)";
 ui_print "-- Kernel Name    : $KERNEL_STRING";
 ui_print "-- Kernel Version : $KERNEL_VERSION";
 ui_print "-- Variant        : $KERNEL_FOR";

--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -469,7 +469,7 @@ KERNEL_FOR="$(file_getprop anykernel.sh kernel.for)";
 KERNEL_COMPILER="$(file_getprop anykernel.sh kernel.compiler)";
 KERNEL_MADE="$(file_getprop anykernel.sh kernel.made)";
 KERNEL_VERSION="$(file_getprop anykernel.sh kernel.version)";
-BUILD_DATE="$(file_getprop anykernel.sh build.date)";
+BUILD_DATE=$(date +%Y-%m-%d)
 MESSAGE_WORD="$(file_getprop anykernel.sh message.word)";
 DEVICE_NAME="$(file_getprop anykernel.sh device.name3)";
 ui_print "-- Kernel Name    : $KERNEL_STRING";

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -10,7 +10,6 @@ kernel.compiler=AtomSemx
 kernel.made=Kunmun
 kernel.version=4.19.xxx
 message.word=bruh
-build.date=2069
 do.devicecheck=1
 do.modules=0
 do.systemless=1

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -19,7 +19,11 @@ device.name1=X01BD
 device.name2=ASUS_X01BD
 device.name3=X01BDA
 device.name4=ASUS_X01BDA
-device.name5=
+device.name5=X00TD
+device.name6=ASUS_X00TD
+device.name7=X00T
+device.name8=ASUS_X00TDA
+device.name9=X00TDA
 supported.versions=11.0-12.0
 supported.patchlevels=
 '; } # end properties


### PR DESCRIPTION
With these patches, no hassle to edit anykernel or get prop from kernel with a build script to edit device name or date. Anykernel can handle that from now on.
And, the X00TD branch can be removed now.
Proposing to change the branch name to `main` or `master` if the patches get approved.